### PR TITLE
reduce number of DB files

### DIFF
--- a/README
+++ b/README
@@ -13,7 +13,9 @@ customize other stuff with =M-x customize-group RET sensetion=.)
 
 Use =M-x sensetion= to start annotating. If this is the first time you
 call it, it might take some time to index the files (you can do other
-stuff on Emacs while it works).
+stuff on Emacs while it works); else it'll read the index files (which
+lie by default in your home directory, prefixed by =.sensetion-=), and
+start the annotation process.
 
 =M-x sensetion-annotate= will ask you for a lemma and a PoS tag. You
 can press =TAB= for completion of the lemma. This will build a buffer
@@ -40,9 +42,7 @@ tokens with the same sense together might be useful.
 
 ** Indexing
 If the index goes out of sync, you can force a new indexation with
-=M-x sensetion-make-index=. This will happen when you change a token's
-lemma, for example; the new lemma will be added to the index, but the
-old one will not be removed.
+=M-x sensetion-make-index=.
 
 
 ** Saving your work
@@ -99,7 +99,11 @@ You may download the =wn= executable from your favorite package
 manager. Be aware that package managers usually offer WordNet 3.1, and
 not WordNet 3.0, which is the WordNet we use to annotate the WN gloss
 corpus. If that is the case, download [[http://wordnetcode.princeton.edu/3.0/WNdb-3.0.tar.gz][WordNet 3.0 database files]], and
-move them to the corresponding directory of package you installed.
+either:
+
+- move them to the corresponding directory of package you installed;
+- or set the =WNSEARCHDIR= variable to the directory of the WordNet
+  3.0 database files.
 
 
 * Annotation format
@@ -125,15 +129,6 @@ To re-run the conversion:
   last parameter is the directory is where you want to put the files, and the
   second parameter is the index.sense file from the WordNet database. (Use absolute paths
   if you have problems with the command.)
-
-
-** indentation 
-
-The elisp indentation of plists differs from the Common Lisp
-indentation. If data is kept in a git repository, it can be useful to
-run the code below in the data directory before commiting:
-
-: for f in `git ls-files -m`; do ~/sensetion.el/identation.sh $f $f.tmp; mv $f.tmp $f; done
 
 
 * Status

--- a/README
+++ b/README
@@ -24,9 +24,13 @@ yet. Unannotated words will show as red/pink, while
 previously-annotated tokens will show as green, and newly-annotated
 tokens will show as blue (all these colors can be customized by the
 user). You can navigate through taggable tokens with =<= and =>=. If
-you wish to annotate a token, press =/= on it. You can see how many
-tokens still need to be annotated in the mode-line, next to the
-=sensetion= indicator.
+you wish to annotate a token, press =/= on it. Select one of the
+options with the appropriate keyboard key; when satisfied, press
+enter/return. If you'd like to quit, press =q=; note that quitting
+does not undo anything (if you selected an option and then quit, its
+effects were carried out and saved). You can see how many tokens still
+need to be annotated in the mode-line, next to the =sensetion=
+indicator.
 
 There is support for word collocations, such as phrasal verbs. The
 tokens part of a collocation are united by a key, which is shown in
@@ -51,6 +55,14 @@ If the index goes out of sync, you can force a new indexation with
 - The updated index is saved by default to your home directory in
   =.sensetion-index= when you quit emacs gracefully (that's why it
   hangs a little). This path is customizable.
+
+
+** Seeing your work
+We recommend setting up a git repository for the annotation files (see
+any git tutorial if you are unfamiliar with it). Use
+: git diff --color-words=.
+(note the period =.=) to see the changes you made after the previous
+commit.
 
 
 * Report bugs
@@ -125,10 +137,11 @@ To re-run the conversion:
 - setup [[https://www.quicklisp.org/beta/][quicklisp]];
 - run:
   : ./convert.sh ~/WordNet-3.0/glosstag/merged/ ~/WordNet-3.0/dict/index.sense glosstag/
-  where the first parameter is a directory is from the gloss corpus archive, the
-  last parameter is the directory is where you want to put the files, and the
-  second parameter is the index.sense file from the WordNet database. (Use absolute paths
-  if you have problems with the command.)
+  where the first parameter is a directory is from the gloss corpus
+  archive, the last parameter is the directory is where you want to
+  put the files, and the second parameter is the index.sense file from
+  the WordNet database. (Use absolute paths if you have problems with
+  the command.)
 
 
 * Status

--- a/README
+++ b/README
@@ -126,13 +126,15 @@ To re-run the conversion:
   second parameter is the index.sense file from the WordNet database. (Use absolute paths
   if you have problems with the command.)
 
-** identation 
 
-The elisp identation differ from CL identation of plists. If data is
-kept in a git repository, it can be useful to run the code below in
-the data directory before commit:
+** indentation 
+
+The elisp indentation of plists differs from the Common Lisp
+indentation. If data is kept in a git repository, it can be useful to
+run the code below in the data directory before commiting:
 
 : for f in `git ls-files -m`; do ~/sensetion.el/identation.sh $f $f.tmp; mv $f.tmp $f; done
+
 
 * Status
 

--- a/convert.lisp
+++ b/convert.lisp
@@ -1,6 +1,7 @@
 (ql:quickload :plump)
 (ql:quickload :serapeum)
 (ql:quickload :alexandria)
+(ql:quickload :ironclad)
 
 (defparameter *sense-map-ht* nil)
 
@@ -146,7 +147,6 @@
            (list :form (node-form node)
                  :lemma (node-lemma node)
                  :pos (node-pos node)
-                 :anno senses
                  :status (alexandria:if-let ((st (node-annotation-tag node)))
                            (if (and (equal st "man") (null senses))
                                "skip"
@@ -158,6 +158,7 @@
                            (:glob (assert (null (cdr coll-keys)))
                             (cons kind (first coll-keys)))
                            (otherwise kind)))
+                 :anno senses
                  :meta (list (list :id (node-get-id node))))))
 
        (node-get-senses (node)
@@ -207,6 +208,15 @@
   (map 'list #'gloss-sentence (plump:child-elements node)))
 
 
+(defun checksum (str)
+  (format nil "~a"
+          (mod
+           (parse-integer
+            (ironclad:byte-array-to-hex-string
+             (ironclad:digest-sequence 'ironclad:sha224 (string-to-octets str))) :start 40 :radix 16)
+           100)))
+
+
 (defun main (glosstag-fp out-fp sensemap-fp &key (*sense-map-ht* *sense-map-ht*))
   (ensure-directories-exist out-fp)
   (with-open-file (in-map sensemap-fp)
@@ -217,16 +227,10 @@
 	    do (with-open-file (in fp)
 		 (let ((sents (wordnet-sentences (aref (plump:child-elements (plump:parse in)) 0))))
 		   (loop for s in sents
-			 do (with-open-file (out (make-pathname :name (getf s :id)
+			 do (with-open-file (out (make-pathname :name (checksum (getf s :id))
 								:type "plist" :defaults out-fp)
-						 :direction :output :if-exists :supersede
+						 :direction :output :if-exists :append
 						 :if-does-not-exist :create)
-			      (write s :case :downcase :stream out)))))))))
-
-
-(defun identation (file-in file-out)
-  (with-open-files ((in file-in)
-		    (out file-out :direction :output :if-exists :supersede))
-    (write (read in) :case :downcase :stream out)))
+			      (write s :pretty nil :case :downcase :stream out)))))))))
 
 

--- a/convert.lisp
+++ b/convert.lisp
@@ -215,7 +215,7 @@
            (parse-integer
             (ironclad:byte-array-to-hex-string
              (ironclad:digest-sequence 'ironclad:sha224 (string-to-octets str))) :start 50 :radix 16)
-           100)))
+           1000)))
 
 
 (defun save-sent (s out-fp)

--- a/convert.sh
+++ b/convert.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-SHOME=/Users/ar/work/sensetion.el
+SHOME="/home/odanoburu/work/sensetion"
 
 sbcl --dynamic-space-size 10Gb --noinform --noprint --load $SHOME/convert.lisp --eval '(time (main (nth 1 sb-ext:*posix-argv*) (nth 3 sb-ext:*posix-argv*) (nth 2 sb-ext:*posix-argv*)))' --quit $1 $2 $3

--- a/sensetion-data.el
+++ b/sensetion-data.el
@@ -1,4 +1,4 @@
-;;; -*- lexical-binding: t; -*-
+;;; sensetion.el --- -*- lexical-binding: t; -*-
 (eval-when-compile (require 'cl-lib))
 (require 'cl-lib)
 

--- a/sensetion-edit.el
+++ b/sensetion-edit.el
@@ -144,4 +144,5 @@
   (add-hook 'kill-buffer-hook 'sensetion--save-edit nil t)
   (setq-local write-contents-functions (list (lambda () (sensetion--save-edit t)))))
 
+
 (provide 'sensetion-edit)

--- a/sensetion-edit.el
+++ b/sensetion-edit.el
@@ -37,6 +37,7 @@
    `(defhydra hydra-senses (:color blue)
       ""
       ("q" nil nil)
+      ("RET" nil nil)
       ("0" ,no-sense-function "No sense in Wordnet" :column "Pick sense:")
       ,@(mapcar
          (lambda (s)
@@ -50,7 +51,7 @@
                                             ,tk-ix
                                             ,sent)
                       (sensetion--edit-reinsert-state-call
-                         ,tk-ix ,sent ,lemma ,st ',options))
+                       ,tk-ix ,sent ,lemma ,st ',options))
                    (sense-help-text sid sense-text)
                    :column "Pick sense:")))
          options)

--- a/sensetion-utils.el
+++ b/sensetion-utils.el
@@ -1,0 +1,62 @@
+;;; -*- lexical-binding: t; -*-
+
+(defun sensetion--punctuation? (str)
+  (gethash
+   str
+   #s(hash-table size 45 test equal rehash-size 1.5 rehash-threshold 0.8125
+                 purecopy t data
+                 ("." t "," t ":" t "!" t "?" t "'" t "]" t ")" t "..." t "»" t))))
+
+
+(defun sensetion--beginning-of-buffer ()
+  (goto-char (point-min)))
+
+
+(defun sensetion--map-lines (file f)
+  "Apply F to each line of FILE.
+
+F must take as argument the point where the line begins and the
+line string itself."
+  (with-temp-buffer
+    (insert-file-contents file)
+    (let (res)
+      (while (not (eobp))
+        (setf res
+              (cons 
+               (funcall f (point) (thing-at-point 'line t))
+               res))
+        (forward-line 1))
+      res)))
+
+
+(defmacro with-inhibiting-read-only (&rest body)
+  `(let ((inhibit-read-only t))
+     ,@body))
+
+
+(defmacro sensetion-is (&rest body)
+  (seq-let (body wclauses)
+      (-split-when (lambda (c) (eq 'where c)) body)
+    (let ((body
+           (-reduce-from
+            (lambda (bd cl)
+              (pcase cl
+                (`(,var ,val)
+                 `((let ((,var ,val))
+                     ,@bd)))
+                (`(,name ,arglist . ,body)
+                 `((cl-labels ((,name ,arglist ,@body))
+                     ,@bd)))))
+            body
+            wclauses)))
+      (cl-first body))))
+
+;; (defmacro defun/where (name arglist &rest body)
+;;   "
+;; \(fn NAME ARGLIST &optional DOCSTRING DECL &rest BODY)"
+;;   (declare (doc-string 3) (indent 2) (debug defun))
+;;   `(defun ,name ,arglist
+;;      (sensetion-is
+;;       ,@body)))
+
+(provide 'sensetion-utils)

--- a/sensetion-utils.el
+++ b/sensetion-utils.el
@@ -15,16 +15,18 @@
 (defun sensetion--map-lines (file f)
   "Apply F to each line of FILE.
 
-F must take as argument the point where the line begins and the
-line string itself."
+F must take as argument the line number and the line string
+itself."
   (with-temp-buffer
     (insert-file-contents file)
-    (let (res)
+    (let (res
+          (counter 0))
       (while (not (eobp))
         (setf res
               (cons 
-               (funcall f (point) (thing-at-point 'line t))
+               (funcall f counter (thing-at-point 'line t))
                res))
+        (cl-incf counter)
         (forward-line 1))
       res)))
 
@@ -58,5 +60,12 @@ line string itself."
 ;;   `(defun ,name ,arglist
 ;;      (sensetion-is
 ;;       ,@body)))
+
+
+(defun sensetion--goto-line (line &optional start-line)
+  (unless start-line
+    (goto-char (point-min)))
+  (let ((sl (or start-line 0)))
+    (forward-line (- line sl))))
 
 (provide 'sensetion-utils)

--- a/sensetion-utils.el
+++ b/sensetion-utils.el
@@ -1,4 +1,4 @@
-;;; -*- lexical-binding: t; -*-
+;;; sensetion.el --- -*- lexical-binding: t; -*-
 
 (defun sensetion--punctuation? (str)
   (gethash

--- a/sensetion.el
+++ b/sensetion.el
@@ -1,4 +1,4 @@
-;;; -*- lexical-binding: t; -*-
+;;; sensetion.el --- -*- lexical-binding: t; -*-
 (require 'seq)
 (require 'subr-x)
 (require 'ido)
@@ -116,7 +116,7 @@ A cons cell in the same format as `sensetion--global-status'.")
     (define-key map "l" #'sensetion-edit-lemma)
     (define-key map "m" #'sensetion-toggle-glob-mark)
     (define-key map "g" #'sensetion-glob)
-    (define-key map "." #'sensetion-go-to-source)
+    (define-key map "." #'sensetion-edit-sent)
     (define-key map [C-down] #'sensetion-move-line-down)
     (define-key map [C-up] #'sensetion-move-line-up)
     map)

--- a/sensetion.el
+++ b/sensetion.el
@@ -179,7 +179,8 @@ annotated."
   (aset (or buffer-display-table
             (setq buffer-display-table (make-display-table)))
         ?\n [?\n?\n])
-  (setq-local mode-name '(:eval (sensetion--mode-line-status-text))))
+  (setq-local mode-name '(:eval (sensetion--mode-line-status-text)))
+  (setq-local write-contents-functions (list (lambda () t))))
 
 
 (defun sensetion--mode-line-status-text ()


### PR DESCRIPTION
current implementation is not as fast as the previous one, but works fine for words not as frequent as `be`. if this turns out to be a problem, it can be fixed.

- use more than one sentence per file
- edit source sentence in special buffer
- closes #71 

* faster CL conversion