### PR TITLE
Multi corpus

### DIFF
--- a/sensetion-client.el
+++ b/sensetion-client.el
@@ -224,7 +224,7 @@
 ;;; mongodb backend
 
 (cl-defstruct (sensetion--mongo (:constructor nil)
-		       (:constructor sensetion--make-mongo))
+		       (:constructor sensetion-make-mongo))
   (db "sensetion-database") (synset-collection "synsets") (document-collection "documents"))
 
 

--- a/sensetion-client.el
+++ b/sensetion-client.el
@@ -39,32 +39,32 @@
 
 (defun sensetion-client-prefix-lemma (prefix)
   "See `sensetion-backend-prefix-lemma'"
-  (sensetion-backend-prefix-lemma sensetion-backend prefix))
+  (sensetion-backend-prefix-lemma (sensetion--project-backend sensetion-current-project) prefix))
 
 (defun sensetion-client-prefix-document-id (prefix)
   "See `sensetion-backend-prefix-document-id'"
-  (sensetion-backend-prefix-document-id sensetion-backend prefix))
+  (sensetion-backend-prefix-document-id (sensetion--project-backend sensetion-current-project) prefix))
 
 (defun sensetion--client-get-sorted-doc-sents (doc-id)
   "See `sensetion--backend-get-sorted-doc-sents'"
-  (sensetion--backend-get-sorted-doc-sents sensetion-backend doc-id))
+  (sensetion--backend-get-sorted-doc-sents (sensetion--project-backend sensetion-current-project) doc-id))
 
 (defun sensetion--client-get-sents (lemma &optional pos)
   "See `sensetion--backend-get-sents'"
-  (sensetion--backend-get-sents sensetion-backend lemma pos))
+  (sensetion--backend-get-sents (sensetion--project-backend sensetion-current-project) lemma pos))
 
 (defun sensetion--client-id->sent (sent_id)
   "See `sensetion--backend-id->sent'"
-  (sensetion--backend-id->sent sensetion-backend sent_id))
+  (sensetion--backend-id->sent (sensetion--project-backend sensetion-current-project) sent_id))
 
 (defun sensetion--client-update-modified-sent (sent)
   "See `sensetion--backend-update-modified-sent'"
   (let ((sent (sensetion--remove-man-now sent)))
-    (sensetion--backend-update-modified-sent sensetion-backend sent)))
+    (sensetion--backend-update-modified-sent (sensetion--project-backend sensetion-current-project) sent)))
 
 (defun sensetion--client-lemma->synsets (lemma pos)
   "See `sensetion--backend-lemma->synsets'"
-  (sensetion--backend-lemma->synsets sensetion-backend lemma pos))
+  (sensetion--backend-lemma->synsets (sensetion--project-backend sensetion-current-project) lemma pos))
 
 
 ;;; elasticsearch backend

--- a/sensetion-client.el
+++ b/sensetion-client.el
@@ -307,7 +307,10 @@ ARGS if present will be used to format CMD."
 
 (cl-defmethod sensetion-backend-prefix-document-id ((backend sensetion--mongo) prefix)
   (let* ((json-array-type 'list)
-	 (output (sensetion--mongo-cmd '((sensetion--mongo-db backend) "--quiet" "--eval" "db.documents.distinct(\"doc_id\")")))
+	 (args (list (sensetion--mongo-db backend) "--quiet" "--eval"
+		     (format "db.%s.distinct(\"doc_id\")"
+			     (sensetion--mongo-document-collection backend))))
+	 (output (sensetion--mongo-cmd args))
 	 (document-ids  (json-read-from-string output)))
     (seq-filter (lambda (document-id) (string-prefix-p prefix document-id)) document-ids)))
 

--- a/sensetion-colloc.el
+++ b/sensetion-colloc.el
@@ -5,10 +5,10 @@
   (sensetion-is
    (list
     (s-concat
-     (when (and target (sensetion--project-identify-sentence-fn sensetion-current-project))
+     (when (and target (sensetion--project-display-meta-data-fn sensetion-current-project))
        (propertize
 	(format "%s "
-		(funcall (sensetion--project-identify-sentence-fn sensetion-current-project) sent))
+		(funcall (sensetion--project-display-meta-data-fn sensetion-current-project) sent))
 	'face 'bold))
      (s-join " " tks))
     (cons done total))

--- a/sensetion-colloc.el
+++ b/sensetion-colloc.el
@@ -5,12 +5,11 @@
   (sensetion-is
    (list
     (s-concat
-     (if (and target sensetion-identify-sentence)
-	 (propertize
-	  (format "(%s %s) "
-		  (sensetion--sent-doc-id sent) (sensetion--sent-sent-id sent))
-	  'face 'bold)
-       "")
+     (when (and target (sensetion--project-identify-sentence-fn sensetion-current-project))
+       (propertize
+	(format "%s "
+		(funcall (sensetion--project-identify-sentence-fn sensetion-current-project) sent))
+	'face 'bold))
      (s-join " " tks))
     (cons done total))
    :where

--- a/sensetion-data.el
+++ b/sensetion-data.el
@@ -4,6 +4,15 @@
 (require 'map)
 (require 's)
 
+(cl-defstruct (sensetion--project (:constructor nil)
+			 (:constructor sensetion--make-project))
+  (name (error "You must provide a name"))
+  (backend (error "You must provide a backend"))
+  (output-buffer-name "sensetion")
+  identify-sentence-fn
+  (restrict-lemmas t)
+  sense-menu-show-synset-id)
+
 ;; TODO: maybe use maps all the way
 (cl-defstruct (sensetion--tk (:constructor nil)
                     (:constructor sensetion--make-tk))

--- a/sensetion-data.el
+++ b/sensetion-data.el
@@ -5,13 +5,38 @@
 (require 's)
 
 (cl-defstruct (sensetion--project (:constructor nil)
-			 (:constructor sensetion--make-project))
-  (name (error "You must provide a name"))
-  (backend (error "You must provide a backend"))
-  (output-buffer-name "sensetion")
-  identify-sentence-fn
-  (restrict-lemmas t)
-  sense-menu-show-synset-id)
+			 (:constructor sensetion-make-project))
+    "Structure representing an annotation project.
+
+Slots:
+
+`name'
+     The name of the project.
+
+`backend'
+     The database backend used by this project.
+
+`output-buffer-name' (optional, default: sensetion)
+     The buffer name where sensetion results are displayed.
+
+`display-meta-data-fn' (optional)
+     Function used to display meta data during target mode. When
+     not defined nothing is displayed.
+
+`restrict-lemmas' (optional, default: t)
+     When non-nil restrict the user to add only lemmas that is part of
+     wordnet to a token or a glob.
+
+`sense-menu-show-synset-id' (optional)
+     When non-nil show synset id in sense menu during annotation.
+"
+
+    (name (error "You must provide a name"))
+    (backend (error "You must provide a backend"))
+    (output-buffer-name "sensetion")
+    display-meta-data-fn
+    (restrict-lemmas t)
+    sense-menu-show-synset-id)
 
 ;; TODO: maybe use maps all the way
 (cl-defstruct (sensetion--tk (:constructor nil)

--- a/sensetion-edit.el
+++ b/sensetion-edit.el
@@ -81,7 +81,8 @@ options in TOKEN."
 					   gloss))))
    :where
    (terms-txt (mapconcat #'bold terms ","))
-   (synset? (if sensetion-sense-menu-show-synset-id (concat "(" (prop sid 'italic) ")") ""))
+   (synset? (if (sensetion--project-sense-menu-show-synset-id sensetion-current-project)
+		(concat "(" (prop sid 'italic) ")") ""))
    (chosen-mark (if chosen? "+ " ""))
    (bold (txt)
 	 (prop txt 'bold))

--- a/sensetion-edit.el
+++ b/sensetion-edit.el
@@ -245,7 +245,7 @@ returns non-nil. None of the arguments may move point."
 (defun sensetion--completing-read-lemma (prompt &optional initial-input)
   (let ((input-lemma (completing-read prompt
 				  sensetion--lemma-completion-function
-				  nil sensetion-restrict-lemmas initial-input)))
+				  nil (sensetion--project-restrict-lemmas sensetion-current-project) initial-input)))
     (sensetion--spaces->underlines input-lemma)))
 
 

--- a/sensetion.el
+++ b/sensetion.el
@@ -30,12 +30,6 @@
   :type '(choice file (const nil)))
 
 
-(defcustom sensetion-backend 'mongo
-  "Choice of database backend."
-  :group 'sensetion
-  :type '(choice (const :tag "mongodb" mongo)
-		 (const :tag "elasticsearch" es)))
-
 (defcustom sensetion-backend-url
   "http://localhost"
   "URL to backend server."

--- a/sensetion.el
+++ b/sensetion.el
@@ -205,10 +205,13 @@ far, and the cdr is the number of annotatable tokens.")
 
 (defun sensetion-select-project ()
   (interactive)
-  (let ((selected (ido-completing-read "Select project: " (mapcar #'sensetion--project-name sensetion-project-list) nil t)))
+  (let ((selected (case (length sensetion-project-list)
+		    (0 (error "sensetion-project-list is empty!"))
+		    (1 (car sensetion-project-list))
+		    (otherwise (find (ido-completing-read "Select project: " (mapcar #'sensetion--project-name sensetion-project-list) nil t)
+				    sensetion-project-list :key #'sensetion--project-name :test #'equal)))))
     (setf sensetion-current-project
-	  (find selected sensetion-project-list
-		:key #'sensetion--project-name :test #'equal))))
+	  selected)))
 
 
 (defun sensetion-sequential-annotate-doc (document-id)


### PR DESCRIPTION
Add flexibility to have more than one annotation project. An example of a list of projects definition:

```lisp
(setf sensetion-project-list
		(list (sensetion-make-project
		       :name "gloss"
		       :backend (sensetion-make-mongo)
		       :display-meta-data-fn (lambda (sent)
					       (format "(%s %s)"
						       (sensetion--sent-doc-id sent)
						       (sensetion--sent-sent-id sent))))))```