### PR TITLE
* fix handling of adjectives

### DIFF
--- a/sensetion-colloc.el
+++ b/sensetion-colloc.el
@@ -105,7 +105,7 @@
 
 
 (defun sensetion--tk-pos-colloc (pos)
-  (propertize (or pos "")
+  (propertize (or (sensetion--pos->string pos) "")
               'display '(raise 0.4)
               'invisible 'sensetion--scripts
               'face '(:height 0.6)))

--- a/sensetion-utils.el
+++ b/sensetion-utils.el
@@ -35,9 +35,11 @@ itself."
 
 
 (defmacro sensetion--with-inhibiting-read-only (&rest body)
-  (declare (debug t) (indent 1))
+  (declare (debug t))
   `(let ((inhibit-read-only t))
      ,@body))
+
+(defalias 'sensetion-λ #'pcase-lambda)
 
 
 (defmacro sensetion-is (&rest body)
@@ -71,20 +73,24 @@ itself."
 
 
 (defun sensetion--spaces->underlines (str)
-  (cl-substitute (string-to-char "_")
+  (cl-substitute ?_
                  (string-to-char " ")
-                 str))
+                 str
+		 :test #'eq))
 
 
 (defsubst sensetion--put-text-property-eol (property value &optional object)
   (put-text-property (line-end-position) (1+ (line-end-position))
 		     property value object))
 
+
 (defsubst sensetion--get-text-property-eol (property &optional object)
   (get-text-property (line-end-position) property object))
 
+
 (defun sensetion--remove-nth (n list)
   (cl-remove-if (lambda (_) t) list :start n :end (1+ n)))
+
 
 (defun sensetion--parse-jsonlines (&optional reverse)
   "Parse and return in a list the newline-delimited JSON values following point.


### PR DESCRIPTION
- because they may be satellites or not we often mishandle them
- show all adjective synsets in sense menu
- pos is now a symbol (mostly)
  - call pos->string to get a human-readable string
  - pos->strings gives ("a" "s"), which non-public functions may use

closes #170